### PR TITLE
Modify Readme for the BoussinesqSphereRTC  model

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,14 +2,25 @@
 
 The model equations are
 
-![Model equations](https://latex.codecogs.com/svg.latex?%5Cinline%20%5Cbegin%7Balign*%7D%20%5Cleft%28%5Cpartial_t%20-%20%5CDelta%5Cright%29%5Cmathbf%7Bu%7D%20%26%20%3D%20%5Cmathbf%7Bu%7D%20%5Ctimes%20%5Cleft%28%20%5Cnabla%20%5Ctimes%20%5Cmathbf%7Bu%7D%5Cright%29%20&plus;%20%5Cfrac%7BRa%7D%7BPr%7D%20%5CTheta%20%5Cmathbf%7Br%7D%20-%20%5Cnabla%5CPi%20%5C%5C%5B0.6cm%5D%20%5Cleft%28%5Cpartial_t%20-%20%5Cfrac%7B1%7D%7BPr%7D%5CDelta%5Cright%29%5CTheta%20%26%20%3D%20%5Cfrac%7BS%7D%7BPr%7D%20-%20%5Cmathbf%7Bu%7D%5Ccdot%5Cnabla%5CTheta%5C%5C%5B0.6cm%5D%20%5Cnabla%5Ccdot%5Cmathbf%7Bu%7D%20%26%20%3D%200%20%5Cend%7Balign*%7D)
+$$
+(\partial_t -\Delta){\bf u}= {\bf u}\times(\nabla\times{\bf u})- \frac{1}{E}\hat{\bf z}\times{\bf u}  -\nabla \Pi + \frac{Ra}{E} \Theta{\bf r}\\
+$$
+
+$$
+(\partial_t -\frac{1}{Pr}\Delta)\Theta = -{\bf u}\cdot\nabla\Theta + \frac{1}{Pr}{\bf u}\cdot{\bf r}
+$$
 
 with the parameters defined as
 
-![Nondimensional parameters](https://latex.codecogs.com/svg.latex?%5Cinline%20%5Cbegin%7Balign*%7D%20Pr%20%26%20%3D%20%5Cfrac%7B%5Cnu%7D%7B%5Ckappa%7D%5C%5C%20Ra%20%26%20%3D%20%5Cfrac%7Bg%20%5Calpha%20%5Cbeta%20r_o%5E4%7D%7B%5Cnu%5Ckappa%7D%20%5Cend%7Balign*%7D)
+$$
+Pr = \frac{\nu}{\kappa};\quad E=\frac{\nu}{2\Omega r_o^2};\quad Ra=\frac{\gamma \alpha \beta r_o^4}{2\nu\Omega}
+$$
 
-The system is solved using a Toroidal/Poloidal decomposition of the velocity ![u](https://latex.codecogs.com/svg.latex?%5Cinline%20%5Cmathbf%7Bu%7D):
+where $\nu$, $\kappa$, $\alpha$ are the kinematic viscosity, thermal conductivity, and thermal expansion coefficents; $\Omega$ is the rotation rate and $r_o$ is the radius of the sphere; $\gamma$ and $\beta$ are defined via the gravitational acceleration, ${\bf g} = -\gamma {\bf r}$, and the background temperature profile for internal heating, $\nabla\Theta_b = -\beta {\bf r}$.
 
-![Toroidal/Poloidal decomposition](https://latex.codecogs.com/svg.latex?%5Cinline%20%5Cmathbf%7Bu%7D%3D%5Cmathbf%7B%5Cnabla%7D%5Ctimes%20T%20%5Cmathbf%7Br%7D%20&plus;%20%5Cmathbf%7B%5Cnabla%7D%5Ctimes%5Cmathbf%7B%5Cnabla%7D%5Ctimes%20P%20%5Cmathbf%7Br%7D)
 
-Note: To access the equations in codecogs online LaTeX editor replace "https://latex.codecogs.com/svg.latex?" with "https://www.codecogs.com/eqnedit.php?latex=".
+The system is solved using a Toroidal/Poloidal decomposition of the velocity
+
+$$
+{\bf u} = \nabla\times T {\bf r} + \nabla\times\nabla\times P {\bf r} 
+$$

--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,7 @@ $$
 $$
 
 $$
-(\partial_t -\frac{1}{Pr}\Delta)\Theta = -{\bf u}\cdot\nabla\Theta + \frac{1}{Pr}{\bf u}\cdot{\bf r}
+(\partial_t -\frac{1}{Pr}\Delta)\Theta = -{\bf u}\cdot\nabla\Theta + {\bf u}\cdot{\bf r}
 $$
 
 with the parameters defined as

--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ $$
 Pr = \frac{\nu}{\kappa};\quad E=\frac{\nu}{2\Omega r_o^2};\quad Ra=\frac{\gamma \alpha \beta r_o^4}{2\nu\Omega}
 $$
 
-where $\nu$, $\kappa$, $\alpha$ are the kinematic viscosity, thermal conductivity, and thermal expansion coefficents; $\Omega$ is the rotation rate and $r_o$ is the radius of the sphere; $\gamma$ and $\beta$ are defined via the gravitational acceleration, ${\bf g} = -\gamma {\bf r}$, and the background temperature profile for internal heating, $\nabla\Theta_b = -\beta {\bf r}$.
+where $\nu$, $\kappa$, $\alpha$ are the kinematic viscosity, thermal conductivity, and thermal expansion coefficents; $\Omega$ is the rotation rate and $r_o$ is the radius of the sphere; $\gamma$ and $\beta$ are defined via the gravitational acceleration, ${\bf g} = -\gamma {\bf r}$, and the background temperature profile for internal heating, $\nabla\Theta_b = -\beta {\bf r}$. The equations have been non-dimensionalised via the viscous time-scale.
 
 
 The system is solved using a Toroidal/Poloidal decomposition of the velocity

--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ $$
 Pr = \frac{\nu}{\kappa};\quad E=\frac{\nu}{2\Omega r_o^2};\quad Ra=\frac{\gamma \alpha \beta r_o^4}{2\nu\Omega}
 $$
 
-where $\nu$, $\kappa$, $\alpha$ are the kinematic viscosity, thermal conductivity, and thermal expansion coefficents; $\Omega$ is the rotation rate and $r_o$ is the radius of the sphere; $\gamma$ and $\beta$ are defined via the gravitational acceleration, ${\bf g} = -\gamma {\bf r}$, and the background temperature profile for internal heating, $\nabla\Theta_b = -\beta {\bf r}$. The equations have been non-dimensionalised via the viscous time-scale.
+where $\nu$, $\kappa$, $\alpha$ are the kinematic viscosity, thermal conductivity, and thermal expansion coefficents; $\Omega$ is the rotation rate and $r_o$ is the radius of the sphere; $\gamma$ and $\beta$ are defined via the gravitational acceleration, ${\bf g} = -\gamma {\bf r}$, and the background temperature profile for internal heating, $\nabla\Theta_b = -\beta {\bf r}$. The equations have been non-dimensionalised via the viscous time-scale, and using $\beta r_o^2$ as temperature scale.
 
 
 The system is solved using a Toroidal/Poloidal decomposition of the velocity


### PR DESCRIPTION
The equations in the original version where not correct. I did my best in recreating what I think are the actually coded equations and parameters' definition based on the equations I can back out from the physical_model.py and from what I think should be going on. They should be double checked, though.

Also, I think now the markdown equations are being rendered properly and there is no real need for codecogs. This, at least, seems to be true on my browser (Firefox on a Mac).